### PR TITLE
Use Gradle 2.6 and Android plugin 1.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.4-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.6-bin.zip


### PR DESCRIPTION
Version 1.3 makes running unit test from AS more reliable with multiple modules (e.g. two apps and a shared library).