### PR TITLE
Add JDK > 8 & new API to CI, use robolectric-4.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,25 @@
 language: android
 
 jdk:
- - oraclejdk8
+  - oraclejdk8
+  - openjdk8
+  - openjdk11
+  - oraclejdk11
+
+env:
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - jdk: openjdk11
+    - jdk: oraclejdk11
 
 android:
   components:
     - platform-tools
     - tools
-    - build-tools-26.0.1
-    - android-26
+    - build-tools-28.0.3
+    - android-28
     - extra-android-support
     - extra-android-m2repository
     - extra-google-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -60,5 +60,5 @@ dependencies {
     testImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     testImplementation 'androidx.test:core:1.0.0'
     testImplementation 'androidx.test.ext:junit:1.0.0'
-    testImplementation 'org.robolectric:robolectric:4.0.1'
+    testImplementation 'org.robolectric:robolectric:4.0.2'
 }


### PR DESCRIPTION
This fixes the Deckard travis builds at the same time it increases the build to be a matrix of 4 different JDKs.

Usefully, if you don't upgrade to robolectric-4.0.2 with this build matrix, you'll see that Java11 was failing - it would have caught that regression for robolectric.4.x

It also includes the 4.0.2 version bump though, so it passes.

@xian  this validates the work on https://github.com/robolectric/robolectric/issues/4085

I would have thrown JDK>=8 into the build matrix on the main robolectric repo but I think you guys are using circle CI now and I don't have any development set up for that. My attempts to bring Travis up for the main repo were thwarted by the mass of the tests causing the jobs to be killed: https://travis-ci.com/mikehardy/robolectric/builds/91103355