### PR TITLE
Fix missing Robolectric 4.2 dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,5 +60,5 @@ dependencies {
     testImplementation 'androidx.test.espresso:espresso-core:3.1.1'
     testImplementation 'androidx.test:core:1.1.0'
     testImplementation 'androidx.test.ext:junit:1.1.0'
-    testImplementation 'org.robolectric:robolectric:4.2'
+    testImplementation 'org.robolectric:robolectric:4.1'
 }


### PR DESCRIPTION
There is no such thing as `org.robolectric:robolectric:4.2` yet, that's why the build failed on the latest commit - https://circleci.com/gh/robolectric/deckard/125

See https://mvnrepository.com/artifact/org.robolectric/robolectric